### PR TITLE
Derive Clone for KeyCollection

### DIFF
--- a/src/verification/key_collection.rs
+++ b/src/verification/key_collection.rs
@@ -4,6 +4,7 @@ use anyhow::{anyhow, Result};
 
 use super::{cache::Cache, fetcher::KeyFetcher, public_key::PublicKey};
 
+#[derive(Debug, Clone)]
 pub struct KeyCollection<C, K, F> {
     phantom_data: PhantomData<K>,
     cache: C,


### PR DESCRIPTION
Only derived when `C` (cache) and `F` (fetcher) derive `Clone`.

Useful when cache is immutable and minimally invasive to the main use case.